### PR TITLE
Codice aliquota iva quando nome non presente.

### DIFF
--- a/src/Gdn.Web.Api.Vs/Features/Invoices/GetInvoiceById.cs
+++ b/src/Gdn.Web.Api.Vs/Features/Invoices/GetInvoiceById.cs
@@ -34,5 +34,6 @@ public class GetInvoiceById
     private static ResponseRow MapResponseRow(InvoiceRow row)
         => new(row.Id, row.RowType, row.Description, row.Quantity, row.UnitPrice,
             row.MeasurementUnitId, row.MeasurementUnit?.Code, row.MeasurementUnit?.Name,
-            row.TaxRateId, row.TaxRate?.Name);
+            row.TaxRateId,
+            string.IsNullOrWhiteSpace(row.TaxRate?.Name) ? row.TaxRate?.Code : row.TaxRate.Name);
 }

--- a/src/Gdn.Web.Api.Vs/Https/TaxRates.http
+++ b/src/Gdn.Web.Api.Vs/Https/TaxRates.http
@@ -1,0 +1,16 @@
+@hostname=localhost
+@port=7256
+@baseUrl=https://{{hostname}}:{{port}}/api
+
+### Get all
+GET {{baseUrl}}/taxrates
+Accept: application/json
+
+###
+
+### Get a single by ID
+@id=1
+GET {{baseUrl}}/taxrates/{{id}}
+Accept: application/json
+
+###

--- a/src/Gdn.Web.Fluentblazor/Components/Invoices/InvoiceRowEditDialog.razor
+++ b/src/Gdn.Web.Fluentblazor/Components/Invoices/InvoiceRowEditDialog.razor
@@ -25,7 +25,7 @@
                                     TOption="TaxRateViewModel"
                                     SelectedOption="SelectedTaxRate"
                                     SelectedOptionChanged="o => SelectedTaxRateChanged(o)"
-                                    OptionText="@(e => e?.Name)"
+                                    OptionText="@(e => string.IsNullOrWhiteSpace(e.Name) ? e.Code : e.Name)"
                                     Label="Aliquota Iva" Height="200px" Width="100%"
                                     Autocomplete="ComboboxAutocomplete.Both" />
                     <FluentValidationMessage For="@(() => Model.TaxRateId)" />
@@ -111,7 +111,7 @@
     {
         SelectedTaxRate = taxRate;
         Model.TaxRateId = taxRate?.Id;
-        Model.TaxRateName = taxRate?.Name;
+        Model.TaxRateName = string.IsNullOrWhiteSpace(taxRate?.Name) ? taxRate?.Code : taxRate.Name;
     }
 
     private async Task SaveAsync()


### PR DESCRIPTION
Nei processi di selezione aliquota iva se il nome dell'aliquota iva non è stato inserito viene visualizzato il suo codice.