### PR TITLE
Refactor dialogs to use reusable CustomerPicker component

### DIFF
--- a/src/Gdn.Web.MudBlazor/Components/CreditNotes/CreditNoteEditDialog.razor
+++ b/src/Gdn.Web.MudBlazor/Components/CreditNotes/CreditNoteEditDialog.razor
@@ -33,16 +33,9 @@
                                        RequiredError="Data richiesta." />
                     </MudItem>
                     <MudItem xs="12" sm="6">
-                        <MudAutocomplete T="CustomerViewModel"
-                                         Label="Cliente"
-                                         Value="_selectedCustomer"
-                                         ValueChanged="OnCustomerChanged"
-                                         SearchFunc="SearchCustomers"
-                                         ToStringFunc="@(c => c?.Name)"
-                                         ResetValueOnEmptyText="true" />
-                        <MudText Typo="Typo.caption" Color="Color.Error">
-                            <ValidationMessage For="@(() => _model.CustomerId)" />
-                        </MudText>
+                        <CustomerPicker CustomerId="_model.CustomerId"
+                                        CustomerIdChanged="OnCustomerChanged"
+                                        ValidationFor="@(() => _model.CustomerId)" />
                     </MudItem>
                     <MudItem xs="12">
                         <MudButton Variant="Variant.Outlined"
@@ -185,9 +178,6 @@
     private EditContext _editContext = default!;
     private bool _saving;
 
-    private IEnumerable<CustomerViewModel> _customers = [];
-    private CustomerViewModel? _selectedCustomer;
-
     private const decimal StampDutyValue = 2.00m;
     private const decimal StampDutyThreshold = 77.47m;
 
@@ -223,25 +213,12 @@
         }
 
         _editContext = new EditContext(_model);
-
-        _customers = await Http.GetFromJsonAsync<IEnumerable<CustomerViewModel>>("customers") ?? [];
-
-        if (_model.CustomerId.HasValue)
-            _selectedCustomer = _customers.FirstOrDefault(c => c.Id == _model.CustomerId);
     }
 
-    private Task<IEnumerable<CustomerViewModel>> SearchCustomers(string? text, CancellationToken ct)
+    private Task OnCustomerChanged(int? customerId)
     {
-        var results = string.IsNullOrWhiteSpace(text)
-            ? _customers
-            : _customers.Where(c => c.Name?.Contains(text, StringComparison.OrdinalIgnoreCase) ?? false);
-        return Task.FromResult(results);
-    }
-
-    private void OnCustomerChanged(CustomerViewModel? customer)
-    {
-        _selectedCustomer = customer;
-        _model!.CustomerId = customer?.Id;
+        _model!.CustomerId = customerId;
+        return Task.CompletedTask;
     }
 
     private async Task SaveAsync()

--- a/src/Gdn.Web.MudBlazor/Components/Customers/CustomerEditDialog.razor
+++ b/src/Gdn.Web.MudBlazor/Components/Customers/CustomerEditDialog.razor
@@ -152,6 +152,20 @@
             response = await Http.PutAsJsonAsync("customers", _model);
 
         if (await Snackbar.ShowResponseErrorAsync(response))
-            Dialog.Close(DialogResult.Ok(_model));
+        {
+            var savedCustomer = await response.Content.ReadFromJsonAsync<CustomerViewModel>() ?? MapCustomerViewModel(_model);
+            _model.Id = savedCustomer.Id;
+            Dialog.Close(DialogResult.Ok(savedCustomer));
+        }
     }
+
+    private static CustomerViewModel MapCustomerViewModel(CustomerEditModel model) => new()
+    {
+        Id = model.Id ?? 0,
+        Code = model.Code,
+        Name = model.Name,
+        Description = model.Description,
+        FiscalCode = model.FiscalCode,
+        VatNumber = model.VatNumber
+    };
 }

--- a/src/Gdn.Web.MudBlazor/Components/Customers/CustomerPicker.razor
+++ b/src/Gdn.Web.MudBlazor/Components/Customers/CustomerPicker.razor
@@ -1,0 +1,137 @@
+@inject HttpClient Http
+@inject IDialogService DialogService
+
+<MudAutocomplete T="CustomerViewModel"
+                 Label="@Label"
+                 Value="_selectedCustomer"
+                 ValueChanged="OnSelectedCustomerChangedAsync"
+                 SearchFunc="SearchCustomersAsync"
+                 ToStringFunc="FormatCustomer"
+                 ResetValueOnEmptyText="true"
+                 Disabled="@Disabled"
+                 Adornment="Adornment.End"
+                 AdornmentIcon="@Icons.Material.Filled.PersonAdd"
+                 AdornmentColor="Color.Primary"
+                 OnAdornmentClick="OnAdornmentClickAsync" />
+@if (ValidationFor is not null)
+{
+    <MudText Typo="Typo.caption" Color="Color.Error">
+        <ValidationMessage For="ValidationFor" />
+    </MudText>
+}
+
+@code {
+    [Parameter]
+    public string Label { get; set; } = "Cliente";
+
+    [Parameter]
+    public int? CustomerId { get; set; }
+
+    [Parameter]
+    public EventCallback<int?> CustomerIdChanged { get; set; }
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    [Parameter]
+    public System.Linq.Expressions.Expression<Func<int?>>? ValidationFor { get; set; }
+
+    private List<CustomerViewModel> _customers = [];
+    private CustomerViewModel? _selectedCustomer;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _customers = await Http.GetFromJsonAsync<List<CustomerViewModel>>("customers") ?? [];
+        SyncSelectedCustomer();
+    }
+
+    protected override void OnParametersSet()
+    {
+        SyncSelectedCustomer();
+    }
+
+    private void SyncSelectedCustomer()
+    {
+        if (_selectedCustomer?.Id == CustomerId)
+        {
+            return;
+        }
+
+        _selectedCustomer = CustomerId.HasValue
+            ? _customers.FirstOrDefault(customer => customer.Id == CustomerId.Value)
+            : null;
+    }
+
+    private Task<IEnumerable<CustomerViewModel>> SearchCustomersAsync(string? text, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IEnumerable<CustomerViewModel> results = string.IsNullOrWhiteSpace(text)
+            ? _customers
+            : _customers.Where(customer =>
+                customer.Name?.Contains(text, StringComparison.OrdinalIgnoreCase) == true ||
+                customer.Code.Contains(text, StringComparison.OrdinalIgnoreCase));
+
+        return Task.FromResult(results);
+    }
+
+    private async Task OnSelectedCustomerChangedAsync(CustomerViewModel? customer)
+    {
+        _selectedCustomer = customer;
+        await CustomerIdChanged.InvokeAsync(customer?.Id);
+    }
+
+    private Task OnAdornmentClickAsync(MouseEventArgs args)
+    {
+        return CreateCustomerAsync();
+    }
+
+    private async Task CreateCustomerAsync()
+    {
+        var parameters = new DialogParameters<CustomerEditDialog>();
+        parameters.Add(dialog => dialog._content, new DialogContent());
+
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = false,
+            CloseButton = false,
+            BackdropClick = false,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
+        };
+
+        var dialog = await DialogService.ShowAsync<CustomerEditDialog>("Nuovo cliente", parameters, options);
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not CustomerViewModel customer)
+        {
+            return;
+        }
+
+        var existingCustomer = _customers.FirstOrDefault(currentCustomer => currentCustomer.Id == customer.Id);
+        if (existingCustomer is null)
+        {
+            _customers.Add(customer);
+        }
+        else
+        {
+            existingCustomer.Code = customer.Code;
+            existingCustomer.Name = customer.Name;
+            existingCustomer.Description = customer.Description;
+            existingCustomer.FiscalCode = customer.FiscalCode;
+            existingCustomer.VatNumber = customer.VatNumber;
+        }
+
+        _selectedCustomer = customer;
+        await CustomerIdChanged.InvokeAsync(customer.Id);
+    }
+
+    private static string? FormatCustomer(CustomerViewModel? customer)
+    {
+        return customer switch
+        {
+            null => null,
+            { Name.Length: > 0 } => customer.Name,
+            _ => customer.Code
+        };
+    }
+}

--- a/src/Gdn.Web.MudBlazor/Components/Interventions/InterventionEditDialog.razor
+++ b/src/Gdn.Web.MudBlazor/Components/Interventions/InterventionEditDialog.razor
@@ -33,17 +33,10 @@
                                        RequiredError="Data richiesta." />
                     </MudItem>
                     <MudItem xs="12" sm="6">
-                        <MudAutocomplete T="CustomerViewModel"
-                                         Label="Cliente"
-                                         Value="_selectedCustomer"
-                                         ValueChanged="OnCustomerChanged"
-                                         SearchFunc="SearchCustomers"
-                                         ToStringFunc="@(c => c?.Name)"
-                                         ResetValueOnEmptyText="true"
-                                         Disabled="@_model.IsInvoiced" />
-                        <MudText Typo="Typo.caption" Color="Color.Error">
-                            <ValidationMessage For="@(() => _model.CustomerId)" />
-                        </MudText>
+                        <CustomerPicker CustomerId="_model.CustomerId"
+                                        CustomerIdChanged="OnCustomerChanged"
+                                        ValidationFor="@(() => _model.CustomerId)"
+                                        Disabled="@_model.IsInvoiced" />
                     </MudItem>
                     <MudItem xs="12">
                         <MudButton Variant="Variant.Outlined"
@@ -118,9 +111,6 @@
     private EditContext _editContext = default!;
     private bool _saving;
 
-    private IEnumerable<CustomerViewModel> _customers = [];
-    private CustomerViewModel? _selectedCustomer;
-
     protected override async Task OnInitializedAsync()
     {
         if (Content.Id == 0)
@@ -135,25 +125,11 @@
         }
 
         _editContext = new EditContext(_model);
-
-        _customers = await Http.GetFromJsonAsync<IEnumerable<CustomerViewModel>>("customers") ?? [];
-
-        if (_model.CustomerId.HasValue)
-            _selectedCustomer = _customers.FirstOrDefault(c => c.Id == _model.CustomerId);
     }
 
-    private Task<IEnumerable<CustomerViewModel>> SearchCustomers(string? text, CancellationToken ct)
+    private Task OnCustomerChanged(int? customerId)
     {
-        var results = string.IsNullOrWhiteSpace(text)
-            ? _customers
-            : _customers.Where(c => c.Name?.Contains(text, StringComparison.OrdinalIgnoreCase) ?? false);
-        return Task.FromResult(results);
-    }
-
-    private Task OnCustomerChanged(CustomerViewModel? customer)
-    {
-        _selectedCustomer = customer;
-        _model!.CustomerId = customer?.Id;
+        _model!.CustomerId = customerId;
         return Task.CompletedTask;
     }
 

--- a/src/Gdn.Web.MudBlazor/Components/Invoices/InvoiceEditDialog.razor
+++ b/src/Gdn.Web.MudBlazor/Components/Invoices/InvoiceEditDialog.razor
@@ -33,16 +33,9 @@
                                        RequiredError="Data richiesta." />
                     </MudItem>
                     <MudItem xs="12" sm="6">
-                        <MudAutocomplete T="CustomerViewModel"
-                                         Label="Cliente"
-                                         Value="_selectedCustomer"
-                                         ValueChanged="OnCustomerChanged"
-                                         SearchFunc="SearchCustomers"
-                                         ToStringFunc="@(c => c?.Name)"
-                                         ResetValueOnEmptyText="true" />
-                        <MudText Typo="Typo.caption" Color="Color.Error">
-                            <ValidationMessage For="@(() => _model.CustomerId)" />
-                        </MudText>
+                        <CustomerPicker CustomerId="_model.CustomerId"
+                                        CustomerIdChanged="OnCustomerChanged"
+                                        ValidationFor="@(() => _model.CustomerId)" />
                     </MudItem>
                     <MudItem xs="12">
                         <MudSelect T="int"
@@ -200,8 +193,6 @@
     private EditContext _editContext = default!;
     private bool _saving;
 
-    private IEnumerable<CustomerViewModel> _customers = [];
-    private CustomerViewModel? _selectedCustomer;
     private IEnumerable<InterventionOptionViewModel> _availableInterventions = [];
     private HashSet<int> _selectedInterventionIds = [];
     private HashSet<int> _originalInterventionIds = [];
@@ -261,35 +252,23 @@
 
         _editContext = new EditContext(_model);
 
-        _customers = await Http.GetFromJsonAsync<IEnumerable<CustomerViewModel>>("customers") ?? [];
-
         if (_model.CustomerId.HasValue)
         {
-            _selectedCustomer = _customers.FirstOrDefault(c => c.Id == _model.CustomerId);
             _selectedInterventionIds = _model.InterventionIds.ToHashSet();
             _originalInterventionIds = _model.InterventionIds.ToHashSet();
             await LoadAvailableInterventionsAsync(_model.CustomerId.Value);
         }
     }
 
-    private Task<IEnumerable<CustomerViewModel>> SearchCustomers(string? text, CancellationToken ct)
+    private async Task OnCustomerChanged(int? customerId)
     {
-        var results = string.IsNullOrWhiteSpace(text)
-            ? _customers
-            : _customers.Where(c => c.Name?.Contains(text, StringComparison.OrdinalIgnoreCase) ?? false);
-        return Task.FromResult(results);
-    }
-
-    private async Task OnCustomerChanged(CustomerViewModel? customer)
-    {
-        _selectedCustomer = customer;
-        _model!.CustomerId = customer?.Id;
+        _model!.CustomerId = customerId;
         _model.InterventionIds.Clear();
         _selectedInterventionIds = [];
         _originalInterventionIds = [];
 
-        if (customer?.Id is int customerId)
-            await LoadAvailableInterventionsAsync(customerId);
+        if (customerId.HasValue)
+            await LoadAvailableInterventionsAsync(customerId.Value);
         else
             _availableInterventions = [];
     }


### PR DESCRIPTION
Replaces inline customer autocomplete and search logic in CreditNoteEditDialog, InvoiceEditDialog, and InterventionEditDialog with a new CustomerPicker component. CustomerPicker centralizes customer selection, search, and creation, improving maintainability and consistency. Dialogs now work with customer IDs only. CustomerEditDialog now returns the saved CustomerViewModel for immediate selection. Removes redundant customer fetching and search code from dialogs.