### PR TITLE
Aggiorna i pacchetti NuGet alla versione piu recente

### DIFF
--- a/src/Gdn.AppHost/Gdn.AppHost.csproj
+++ b/src/Gdn.AppHost/Gdn.AppHost.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Gdn.Persistence/Gdn.Persistence.csproj
+++ b/src/Gdn.Persistence/Gdn.Persistence.csproj
@@ -5,13 +5,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Gdn.Domain\Gdn.Domain.csproj" />

--- a/src/Gdn.ServiceDefaults/Gdn.ServiceDefaults.csproj
+++ b/src/Gdn.ServiceDefaults/Gdn.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Gdn.Web.Api.Vs/Gdn.Web.Api.Vs.csproj
+++ b/src/Gdn.Web.Api.Vs/Gdn.Web.Api.Vs.csproj
@@ -5,16 +5,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FatturaElettronica" Version="4.0.7" />
+    <PackageReference Include="FatturaElettronica" Version="4.0.8" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="QuestPDF" Version="2026.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
-    <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.21" />
+    <PackageReference Include="QuestPDF" Version="2026.7.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
+    <PackageReference Include="TinyHelpers.AspNetCore" Version="4.2.17" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Gdn.Persistence\Gdn.Persistence.csproj" />

--- a/src/Gdn.Web.MudBlazor/Gdn.Web.MudBlazor.csproj
+++ b/src/Gdn.Web.MudBlazor/Gdn.Web.MudBlazor.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
-    <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
+    <PackageReference Include="MudBlazor" Version="9.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Perche
Allineare la soluzione alle versioni NuGet piu recenti riduce il rischio di vulnerabilita note e mantiene il progetto aggiornato con fix e miglioramenti compatibili.

## Cosa cambia
- Aggiornati i riferimenti `Aspire.Hosting.AppHost` in AppHost.
- Aggiornati i pacchetti Entity Framework Core e `Microsoft.Extensions.DependencyInjection.Abstractions` nel layer Persistence.
- Aggiornati i pacchetti `Microsoft.Extensions.*` e OpenTelemetry nel progetto ServiceDefaults.
- Aggiornati i pacchetti API principali (`FatturaElettronica`, `Microsoft.AspNetCore.OpenApi`, `QuestPDF`, `Swashbuckle.AspNetCore.SwaggerUI`, `TinyHelpers.AspNetCore`).
- Aggiornati i pacchetti Blazor WebAssembly e MudBlazor nel frontend.

## Note per la review
- L'aggiornamento e limitato ai riferimenti NuGet espliciti nei file `.csproj`, senza modifiche funzionali al codice applicativo.
- Durante il lavoro si sono verificati timeout intermittenti verso `api.nuget.org`; la branch contiene comunque gli aggiornamenti dei riferimenti di versione previsti.